### PR TITLE
Adds dynamic import flag

### DIFF
--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -24,6 +24,7 @@
     "@babel/plugin-syntax-async-generators": "^7.0.0",
     "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
     "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-transform-arrow-functions": "^7.0.0",
     "@babel/plugin-transform-async-to-generator": "^7.1.0",
     "@babel/plugin-transform-block-scoped-functions": "^7.0.0",

--- a/packages/babel-preset-env/src/available-plugins.js
+++ b/packages/babel-preset-env/src/available-plugins.js
@@ -2,6 +2,7 @@ export default {
   "syntax-async-generators": require("@babel/plugin-syntax-async-generators"),
   "syntax-object-rest-spread": require("@babel/plugin-syntax-object-rest-spread"),
   "syntax-optional-catch-binding": require("@babel/plugin-syntax-optional-catch-binding"),
+  "syntax-dynamic-import": require("@babel/plugin-syntax-dynamic-import"),
   "transform-async-to-generator": require("@babel/plugin-transform-async-to-generator"),
   "proposal-async-generator-functions": require("@babel/plugin-proposal-async-generator-functions"),
   "proposal-json-strings": require("@babel/plugin-proposal-json-strings"),

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -159,6 +159,10 @@ function supportsStaticESM(caller) {
   return !!(caller && caller.supportsStaticESM);
 }
 
+function supportsDynamicImport(caller) {
+  return !!(caller && caller.supportsDynamicImport);
+}
+
 export default declare((api, opts) => {
   api.assertVersion(7);
 
@@ -246,6 +250,10 @@ export default declare((api, opts) => {
     // NOTE: not giving spec here yet to avoid compatibility issues when
     // transform-modules-commonjs gets its spec mode
     plugins.push([getPlugin(moduleTransformations[modules]), { loose }]);
+  }
+
+  if (api.caller && api.caller(supportsDynamicImport)) {
+    plugins.push([getPlugin("syntax-dynamic-import")]);
   }
 
   transformations.forEach(pluginName =>

--- a/packages/babel-preset-env/test/fixtures/modules/dynamic-imports/input.js
+++ b/packages/babel-preset-env/test/fixtures/modules/dynamic-imports/input.js
@@ -1,0 +1,3 @@
+import('async-module').then(asyncModule => {
+  console.log(asyncModule.hello);
+});

--- a/packages/babel-preset-env/test/fixtures/modules/dynamic-imports/options.json
+++ b/packages/babel-preset-env/test/fixtures/modules/dynamic-imports/options.json
@@ -1,0 +1,9 @@
+{
+  "caller": {
+    "name": "test-fixture",
+    "supportsDynamicImport": true
+  },
+  "presets": [
+    ["env"]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/modules/dynamic-imports/output.js
+++ b/packages/babel-preset-env/test/fixtures/modules/dynamic-imports/output.js
@@ -1,0 +1,3 @@
+import('async-module').then(function (asyncModule) {
+  console.log(asyncModule.hello);
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes babel/babel-loader#515
| Patch: Bug Fix?          | ❌
| Major: Breaking Change?  | ❌
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | 👍
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | 👍
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This interprets the `supportsDynamicImport` caller flag. It was introduced in babel-loader by babel/babel-loader#660 and signals that the target env supports dynamic imports natively.

When this gets merged, it should no longer be necessary to manually include the dynamic import syntax plugin in the webpack config. Thus fixing babel/babel-loader#515.

References: babel/babel-loader#714, babel/babel-loader#515
